### PR TITLE
add timeouts

### DIFF
--- a/redis-queue.js
+++ b/redis-queue.js
@@ -8,6 +8,7 @@ const {randomBytes} = require("crypto");
  * @param {string} [options.dead_key]
  * @param {string} [options.recover_key]
  * @param {RedisClient|string|URL} [options.redis]
+ * @param {function} [options.retry]
  * @returns {RedisQueue}
  */
 function redisQueue({
@@ -73,8 +74,6 @@ function redisQueue({
             if (typeof value === "string") {
                 // call handler; retry with fresh copy of value each call
                 await retry(() => handleValue(JSON.parse(value)));
-            } else if (value === null) {
-                throw new Error("this is the problem");
             }
 
             // clean up transaction


### PR DESCRIPTION
Adds proper timeouts for transactions so multiple workers don't interfere with one another.

Puts recovery on a timer, so that if a worker fails and does not come back up, other workers will re-claim that workers transactions.  Previously, recovery ran only when a worker started up, so transactions wouldn't be recovered until one of the workers restarts.

Timeouts aren't being test here, because Redis is ultimately responsible for handling the timeouts, but the Redis mock library doesn't handle .expire properly.